### PR TITLE
CRD Spec: add option to configure HostNetwork and DNSPolicy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1004,6 +1004,7 @@
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/fields",

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -162,6 +162,12 @@ type PodPolicy struct {
 	// '.cluster.local'.
 	// The default is to not set a cluster domain explicitly.
 	ClusterDomain string `json:"ClusterDomain"`
+
+	// hostNetwork will set HostNetwork: true in podspec
+	HostNetwork bool `json:"hostNetwork,omitempty"`
+
+	// dnsPolicy will set dnsPolicy: <whatever> in podspec
+	DNSPolicy v1.DNSPolicy `json:"dnsPolicy,omitempty"`
 }
 
 // TODO: move this to initializer

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -402,6 +402,15 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 			SecurityContext:              podSecurityContext(cs.Pod),
 		},
 	}
+
+	if cs.Pod.DNSPolicy != "" {
+		pod.Spec.DNSPolicy = cs.Pod.DNSPolicy
+	}
+
+	if cs.Pod.HostNetwork {
+		pod.Spec.HostNetwork = true
+	}
+
 	SetEtcdVersion(pod, cs.Version)
 	return pod
 }


### PR DESCRIPTION
Quoting the original commit message.

---

this allows the network plugins like CNI to use etcd-cluster
as kv when bootstrapping the cluster

fixes #1929


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
