### PR TITLE
Cache vendor directory to speed up Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ go_import_path: github.com/coreos/etcd-operator
 before_install: go get -u github.com/golang/dep/cmd/dep
 install:
 - ./hack/update_vendor.sh
+cache:
+  directories:
+  - vendor
 script:
 - ./hack/build/operator/build
 - ./hack/build/backup-operator/build


### PR DESCRIPTION
Cuts the build time from 9min https://app.travis-ci.com/github/form3tech-oss/etcd-operator/builds/244011486 to 2min https://app.travis-ci.com/github/form3tech-oss/etcd-operator/jobs/553591949