### PR TITLE
ci: add missing deploy credentials

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,6 @@ jobs:
       - name: Deploy
         run: ./hack/deploy.sh
         if: startsWith(github.ref, 'refs/tags')
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}


### PR DESCRIPTION
## Description
Fixes the deploy step by adding missing docker hub credentials.