### PR TITLE
feat: add failurePolicy and scalingTimeout to CRD spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,12 +101,12 @@ require (
 	go.opencensus.io v0.22.3 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.17.0 // indirect
+	go.uber.org/zap v1.18.1 // indirect
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
-	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
+	golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/tools v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/aws/aws-sdk-go v1.13.8/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoM
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f h1:ZNv7On9kyUzm7fvRZumSyy/IUiSC7AzL0I1jKKtwooA=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -469,13 +471,15 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
-go.uber.org/zap v1.17.0 h1:MTjgFu6ZLKvY6Pvaqk97GlxNBuMpV4Hy/3P6tRGlI2U=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+go.uber.org/zap v1.18.1 h1:CSUJ2mjFszzEWt4CdKISEuChVIXGBn3lAPwkRGyVrc4=
+go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -613,8 +617,9 @@ golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -91,6 +91,15 @@ type ClusterSpec struct {
 
 	// Paused is to pause the control of the operator for the etcd cluster.
 	Paused bool `json:"paused,omitempty"`
+
+	// ScalingTimeout defines how long a cluster is allowed to stay in scaling mode
+	// If the cluster exceeds the timeout it goes into a failed state.
+	// If not set it can stay there indefinitely.
+	ScalingTimeout *metav1.Duration `json:"scalingTimeout,omitempty"`
+
+	// FailurePolicy defines how to handle a failed cluster
+	// Defaults to retain the cluster state on failure
+	FailurePolicy FailurePolicy `json:"failurePolicy,omitempty"`
 
 	// Pod defines the policy to create pod for the etcd pod.
 	//
@@ -169,6 +178,13 @@ type PodPolicy struct {
 	// dnsPolicy will set dnsPolicy: <whatever> in podspec
 	DNSPolicy v1.DNSPolicy `json:"dnsPolicy,omitempty"`
 }
+
+type FailurePolicy string
+
+const (
+	FailurePolicyRetain   FailurePolicy = "Retain"
+	FailurePolicyRecreate FailurePolicy = "Recreate"
+)
 
 // TODO: move this to initializer
 func (c *ClusterSpec) Validate() error {

--- a/pkg/apis/etcd/v1beta2/status.go
+++ b/pkg/apis/etcd/v1beta2/status.go
@@ -179,6 +179,19 @@ func (cs *ClusterStatus) setClusterCondition(c ClusterCondition) {
 	}
 }
 
+func (cs *ClusterStatus) GetCondition(t ClusterConditionType) *ClusterCondition {
+	_, c := getClusterCondition(cs, t)
+	return c
+}
+
+func (cs *ClusterStatus) LastTransitionTime(t ClusterConditionType) (time.Time, error) {
+	_, c := getClusterCondition(cs, t)
+	if c == nil {
+		return time.Time{}, fmt.Errorf("no time set")
+	}
+	return time.Parse(time.RFC3339, c.LastTransitionTime)
+}
+
 func getClusterCondition(status *ClusterStatus, t ClusterConditionType) (int, *ClusterCondition) {
 	for i, c := range status.Conditions {
 		if t == c.Type {


### PR DESCRIPTION
### Underlying problem
When we bootstrap an etcd cluster for cilium we may run into connectivity issues on the path `etcd-operator` -> `cilium-etcd-member` which does not recover automatically. To recover we need to manually re-create the Pods (or rather: the complete cluster). 

The Operator does not recover and is stuck in a loop. Once it fails on `rerr = c.reconcile(..)` it will stay in this indefinitely and does not recover, because there is no network connectivity to `etcd-member`: It fails with `failed to update members: context deadline exceeded`


https://github.com/form3tech-oss/etcd-operator/blob/7dd3a593aa8a264adb8f9e73b0c8de8d0c662591/pkg/cluster/cluster.go#L267-L272


Data loss is not a problem in this case.

### Feature Proposal
`scalingTimeout` defines how long a cluster is allowed to stay in scaling mode.
If it exceeds the limit the cluster will go into a failed state.

`failurePolicy` defines how to handle a failed cluster. By default it will
retain the existing pods. This can be set to Recreate to trigger re-creation
of an etcd cluster.

These two fields work together to ensure that if a cluster creation times out
it will be re-created from scratch.

This PR solves two problems:
1. `etcd-operator` is not able to form a cluster in a reasonable timeframe
2. `etcd-operator` is not able to recover from connectivity issues that requires re-creation of an etcd-member pod


### Proof of work

Run operator and create the following cluster:
```yaml
apiVersion: "etcd.database.coreos.com/v1beta2"
kind: "EtcdCluster"
metadata:
  name: "example-etcd-cluster"
spec:
  failurePolicy: Recreate
  scalingTimeout: 3m
  size: 3
  version: "3.4.7"
```

Scenario: Wait until two pods come up and kill the 3rd when it is in `Initializing` phase. After `scalingTimeout` the whole cluster will be re-created.