### PR TITLE
Make PDB and PriorityClass configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [Release 0.9.4-10]
+
+### Added
+
+- Option to disable `PodDisruptionBudget` (defaults to enabled).
+- Make the PriorityClass member pods are launched with configurable (currently pods get deployed with system-cluster-critical which remains the default)
+
+### Changed
+
+### Removed
+
+### Fixed
+
 ## [Release 0.9.4-9]
 
 ### Added

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -393,7 +393,12 @@ func (c *Cluster) setupServices() error {
 }
 
 func (c *Cluster) setupPodDisruptionBudget() error {
-	return k8sutil.CreatePDB(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.Spec.Size, c.cluster.AsOwner())
+	// default to true
+	enabled := c.cluster.Spec.EnablePDB == nil || *c.cluster.Spec.EnablePDB
+	if enabled {
+		return k8sutil.CreatePDB(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.Spec.Size, c.cluster.AsOwner())
+	}
+	return nil
 }
 
 func (c *Cluster) isPodPVEnabled() bool {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -380,9 +380,15 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 	}
 
 	DNSTimeout := defaultDNSTimeout
+	PriorityClassName := api.DefaultPriorityClassName
+
 	if cs.Pod != nil {
 		DNSTimeout = cs.Pod.DNSTimeoutInSecond
+		if cs.Pod.PriorityClassName != "" {
+			PriorityClassName = cs.Pod.PriorityClassName
+		}
 	}
+
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        m.Name,
@@ -415,7 +421,7 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 			}},
 			Containers:        []v1.Container{container},
 			RestartPolicy:     v1.RestartPolicyNever,
-			PriorityClassName: "system-cluster-critical",
+			PriorityClassName: PriorityClassName,
 			Volumes:           volumes,
 			// DNS A record: `[m.Name].[clusterName].Namespace.svc`
 			// For example, etcd-795649v9kq in default namesapce will have DNS name

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	Version = "0.9.4-8"
+	Version = "0.9.4-10"
 	GitSHA  = "Not provided (use ./build instead of go build)"
 )


### PR DESCRIPTION
Hey folks,

Thanks for maintaining this fork, I'm hoping to use the latest version but ran into some issues. Changes below

- Some cloud providers / clusters restrict what priority class pods can run outside of kube-system, so this makes the priority class member pods get launched with configurable
- If users have already defined a PDB manually, it would be useful to disable the operator managed PDB.